### PR TITLE
undid spelling mistakes of a certain someone

### DIFF
--- a/include/blockyalgorithm.hpp
+++ b/include/blockyalgorithm.hpp
@@ -12,7 +12,7 @@ using namespace std;
 class BlockyAlgorithm
 {
 public:
-    shared_ptr<Reporter> compress(FILE* file, int width, int elements)
+    shared_ptr<Reporter> compress(FILE* file, size_t width, int elements)
     {
         if (width == 1)
             return shared_ptr<Reporter>(new BlockyCompression(file));

--- a/include/methods/compressionmethod.hpp
+++ b/include/methods/compressionmethod.hpp
@@ -55,7 +55,7 @@ public:
     (
         BitWriter& writer,
         Block block,
-        int32_t& valueIndex
+        size_t& valueIndex
     ) = 0;
 };
 

--- a/include/methods/floatsimilar/floatsimilarcompression.hpp
+++ b/include/methods/floatsimilar/floatsimilarcompression.hpp
@@ -1,15 +1,15 @@
-#ifndef FLOATSIMMILARCOMPRESSION_HPP
-#define FLOATSIMMILARCOMPRESSION_HPP
+#ifndef FLOATSIMILARCOMPRESSION_HPP
+#define FLOATSIMILARCOMPRESSION_HPP
 
 #include <methods/compressionmethod.hpp>
 
-class FloatSimmilarCompression
+class FloatSimilarCompression
     : public CompressionMethod
 {
 private:
 
 public:
-    FloatSimmilarCompression
+    FloatSimilarCompression
     (
         vector<shared_ptr<BlockyNumber>> const& values,
         BlockyMetadata const& metadata,
@@ -30,7 +30,7 @@ public:
     (
         BitWriter& writer,
         Block block,
-        int32_t& valueIndex
+        size_t& valueIndex
     ) override;
 };
 

--- a/include/methods/methods.hpp
+++ b/include/methods/methods.hpp
@@ -6,7 +6,7 @@ static const int METHODS_COUNT = 5;
 enum struct Methods
 {
     PatternSame,
-    FloatSimmilar,
+    FloatSimilar,
     NumbersNoExp,
     PatternOffset,
     PatternPingPong

--- a/include/methods/numbersnoexp/numbersnoexpcompression.hpp
+++ b/include/methods/numbersnoexp/numbersnoexpcompression.hpp
@@ -1,16 +1,16 @@
-#ifndef NUMMBERSNOEXPCOMPRESSION_HPP
-#define NUMMBERSNOEXPCOMPRESSION_HPP
+#ifndef NUMBERSNOEXPCOMPRESSION_HPP
+#define NUMBERSNOEXPCOMPRESSION_HPP
 
 #include <methods/compressionmethod.hpp>
 
-class NummbersNoExpCompression
+class NumbersNoExpCompression
     : public CompressionMethod
 {
 private:
     /* data */
 
 public:
-    NummbersNoExpCompression
+    NumbersNoExpCompression
     (
         vector<shared_ptr<BlockyNumber>> const& values,
         BlockyMetadata const& metadata,
@@ -31,7 +31,7 @@ public:
     (
         BitWriter& writer,
         Block block,
-        int32_t& valueIndex
+        size_t& valueIndex
     ) override;
 };
 

--- a/include/methods/patternoffset/patternoffsetcompression.hpp
+++ b/include/methods/patternoffset/patternoffsetcompression.hpp
@@ -31,7 +31,7 @@ public:
     (
         BitWriter& writer,
         Block block,
-        int32_t& valueIndex
+        size_t& valueIndex
     ) override;
 };
 

--- a/include/methods/patternpingpong/patternpingpongcompression.hpp
+++ b/include/methods/patternpingpong/patternpingpongcompression.hpp
@@ -60,7 +60,7 @@ public:
     (
         BitWriter& writer,
         Block block,
-        int32_t& valueIndex
+        size_t& valueIndex
     ) override;
 };
 

--- a/include/methods/patternsame/patternsamecompression.hpp
+++ b/include/methods/patternsame/patternsamecompression.hpp
@@ -31,7 +31,7 @@ public:
     (
         BitWriter& writer,
         Block block,
-        int32_t& valueIndex
+        size_t& valueIndex
     ) override;
 };
 

--- a/src/blockfinding/blockfinding.cpp
+++ b/src/blockfinding/blockfinding.cpp
@@ -2,7 +2,7 @@
 
 #include <blockfinding/blockfinding.hpp>
 
-#include <methods/floatsimmilar/floatsimmilarcompression.hpp>
+#include <methods/floatsimilar/floatsimilarcompression.hpp>
 #include <methods/numbersnoexp/numbersnoexpcompression.hpp>
 #include <methods/patternoffset/patternoffsetcompression.hpp>
 #include <methods/patternpingpong/patternpingpongcompression.hpp>
@@ -35,8 +35,8 @@ Blockfinding::Blockfinding
             Headers,
             initializedCompressionMethods
         );
-    initializedCompressionMethods[(int)Methods::FloatSimmilar] =
-        new FloatSimmilarCompression
+    initializedCompressionMethods[(int)Methods::FloatSimilar] =
+        new FloatSimilarCompression
         (
             values,
             metadata,
@@ -44,7 +44,7 @@ Blockfinding::Blockfinding
             initializedCompressionMethods
         );
     initializedCompressionMethods[(int)Methods::NumbersNoExp] =
-        new NummbersNoExpCompression
+        new NumbersNoExpCompression
         (
             values,
             metadata,
@@ -313,7 +313,7 @@ bool Blockfinding::process_next_value()
     auto isLastBlockUp2Date =
         lastStableBlock.Index + lastStableBlock.Length - 1 == index;
 
-    for (int32_t j = 0; j < calculations.size(); j++)
+    for (size_t j = 0; j < calculations.size(); j++)
     {
         auto calc = calculations[j];
 
@@ -447,7 +447,7 @@ bool Blockfinding::process_next_value()
                             value.IsNegative,
                             value.Number,
                             initializedCompressionMethods,
-                            Methods::FloatSimmilar,
+                            Methods::FloatSimilar,
                             false
                         )
                     );

--- a/src/blockycompression.cpp
+++ b/src/blockycompression.cpp
@@ -146,11 +146,11 @@ void BlockyCompression::post_compression_optimisation()
 
 void BlockyCompression::write()
 {
-    auto currentBlockIndex = 0;
+    size_t currentBlockIndex = 0;
 
     auto valueCount = Values.size();
-    auto blockCount = Blocks.size();
-    auto nextStop = blockCount == 0
+    size_t blockCount = Blocks.size();
+    size_t nextStop = blockCount == 0
       ? valueCount : Blocks[currentBlockIndex].Index;
 
     auto hasExponent = !Metadata.NoExponent;
@@ -160,7 +160,7 @@ void BlockyCompression::write()
     writer.write_byte(0, 1); // dont use huffman
     std::cout << "meta" << std::endl;
 
-    for (auto i = 0; i < valueCount;)
+    for (size_t i = 0; i < valueCount;)
     {
         for (; nextStop > i; i++) // writing values until the next block is here
         {

--- a/src/methods/floatsimilar/floatsimilarcompression.cpp
+++ b/src/methods/floatsimilar/floatsimilarcompression.cpp
@@ -1,11 +1,11 @@
 #include <cmath>
 #include <algorithm>
 
-#include "methods/floatsimmilar/floatsimmilarcompression.hpp"
+#include "methods/floatsimilar/floatsimilarcompression.hpp"
 
 using namespace std;
 
-bool FloatSimmilarCompression::process_value
+bool FloatSimilarCompression::process_value
 (
     Block& block,
     const BlockyNumber& value,
@@ -121,11 +121,11 @@ bool FloatSimmilarCompression::process_value
     return true;
 }
 
-void FloatSimmilarCompression::write
+void FloatSimilarCompression::write
 (
     BitWriter& writer,
     Block block,
-    int32_t& valueIndex
+    size_t& valueIndex
 )
 {
     write_default_blockheader(writer, block);
@@ -135,7 +135,7 @@ void FloatSimmilarCompression::write
         writer.write_byte(1, 1);
         writer.write
         (
-            metadata.MaxNeededBitsNumber,
+			metadata.MaxNeededBitsNumber,
             metadata.MaxNeededBitsNeededBitsNumber
         );
     }

--- a/src/methods/numbersnoexp/numbersnoexpcompression.cpp
+++ b/src/methods/numbersnoexp/numbersnoexpcompression.cpp
@@ -1,6 +1,6 @@
 #include <methods/numbersnoexp/numbersnoexpcompression.hpp>
 
-bool NummbersNoExpCompression::process_value
+bool NumbersNoExpCompression::process_value
 (
     Block& block,
     const BlockyNumber& value,
@@ -42,11 +42,11 @@ bool NummbersNoExpCompression::process_value
 }
 
 
-void NummbersNoExpCompression::write
+void NumbersNoExpCompression::write
 (
     BitWriter& writer,
     Block block,
-    int32_t& valueIndex
+    size_t& valueIndex
 )
 {
     write_default_blockheader(writer, block);

--- a/src/methods/patternoffset/patternoffsetcompression.cpp
+++ b/src/methods/patternoffset/patternoffsetcompression.cpp
@@ -47,7 +47,7 @@ bool PatternOffsetCompression::process_value
         {
             bitDiff += headers.StandardBlockPatternOffset
               - headers.StandardBlockFloatSimmilar;
-            block.Method = methods[(int)Methods::FloatSimmilar];
+            block.Method = methods[(int)Methods::FloatSimilar];
             block.Exponent = firstValue.Exponent;
         }
         else
@@ -91,7 +91,7 @@ void PatternOffsetCompression::write
 (
     BitWriter& writer,
     Block block,
-    int32_t& valueIndex
+    size_t& valueIndex
 )
 {
     write_default_blockheader(writer, block);

--- a/src/methods/patternpingpong/patternpingpongcompression.cpp
+++ b/src/methods/patternpingpong/patternpingpongcompression.cpp
@@ -16,7 +16,7 @@ void PatternPingPongCompression::write
 (
     BitWriter& writer,
     Block block,
-    int32_t& valueIndex
+    size_t& valueIndex
 )
 {
     write_default_blockheader(writer, block);

--- a/src/methods/patternsame/patternsamecompression.cpp
+++ b/src/methods/patternsame/patternsamecompression.cpp
@@ -68,7 +68,7 @@ bool PatternSameCompression::process_value
             return true;
         }
         auto oldMethod = block.Method;
-        block.Method = methods[(int)Methods::FloatSimmilar];
+        block.Method = methods[(int)Methods::FloatSimilar];
         block.Exponent = firstValue.Exponent;
         block.HasExponent = true;
         bitDiff += headers.StandardBlockPatternSame
@@ -99,7 +99,7 @@ void PatternSameCompression::write
 (
     BitWriter& writer,
     Block block,
-    int32_t& valueIndex
+    size_t& valueIndex
 )
 {
     write_default_blockheader(writer, block);

--- a/src/parsing/parser.cpp
+++ b/src/parsing/parser.cpp
@@ -133,6 +133,8 @@ void Parser::parse(int w)
 			skip(2);
 			try
 			{
+				// TODO: check whether string can be parsed 
+				// to double with an invalid argument exception
 				double a = stod(tkn->Payload);
 				result = parse_anonymous_list(int32_t(a));
 			}
@@ -461,6 +463,8 @@ ParserResult Parser::parse_value(Token const& me)
 			skip(2);
 			try
 			{
+				// TODO: check whether string can be parsed 
+				// to double with an invalid argument exception
 				double a = stod(me.Payload);
 				result = parse_anonymous_list(int32_t(a));
 				if (result != ParserResult::SUCCESS)


### PR DESCRIPTION
floatsimmilar -> floatsimilar
nummbersnoexp -> numbersnoexp
also removed some auto typing and signed/unsigned type comparisons